### PR TITLE
Role has "long Id"

### DIFF
--- a/src/Abp.Zero.NHibernate/Zero/NHibernate/EntityMappings/RoleMap.cs
+++ b/src/Abp.Zero.NHibernate/Zero/NHibernate/EntityMappings/RoleMap.cs
@@ -1,5 +1,6 @@
 using Abp.Authorization.Roles;
 using Abp.Authorization.Users;
+using Abp.Domain.Entities;
 using Abp.MultiTenancy;
 using Abp.NHibernate.EntityMappings;
 
@@ -8,8 +9,8 @@ namespace Abp.Zero.NHibernate.EntityMappings
     /// <summary>
     /// Base class for role mapping.
     /// </summary>
-    public abstract class RoleMap<TTenant, TRole, TUser> : EntityMap<TRole>
-        where TRole : AbpRole<TTenant, TUser>
+    public abstract class RoleMap<TTenant, TRole, TUser> : EntityMap<TRole, long> 
+        where TRole : AbpRole<TTenant, TUser>, IEntity<long>
         where TUser : AbpUser<TTenant, TUser>
         where TTenant : AbpTenant<TTenant, TUser>
     {

--- a/src/Abp.Zero/Authorization/Roles/AbpRole.cs
+++ b/src/Abp.Zero/Authorization/Roles/AbpRole.cs
@@ -20,7 +20,7 @@ namespace Abp.Authorization.Roles
     /// A user can have multiple roles. Thus, user will have all permissions of all assigned roles.
     /// </remarks>
     [Table("AbpRoles")]
-    public class AbpRole<TTenant, TUser> : FullAuditedEntity<int, TUser>, IRole<int>, IMayHaveTenant<TTenant, TUser>
+    public class AbpRole<TTenant, TUser> : FullAuditedEntity<long, TUser>, IRole<long>, IMayHaveTenant<TTenant, TUser>
         where TUser : AbpUser<TTenant, TUser>
         where TTenant : AbpTenant<TTenant, TUser>
     {

--- a/src/Abp.Zero/Authorization/Roles/AbpRoleManager.cs
+++ b/src/Abp.Zero/Authorization/Roles/AbpRoleManager.cs
@@ -19,7 +19,7 @@ namespace Abp.Authorization.Roles
     /// Extends <see cref="RoleManager{TRole,TKey}"/> of ASP.NET Identity Framework.
     /// Applications should derive this class with appropriate generic arguments.
     /// </summary>
-    public abstract class AbpRoleManager<TTenant, TRole, TUser> : RoleManager<TRole, int>, ITransientDependency
+    public abstract class AbpRoleManager<TTenant, TRole, TUser> : RoleManager<TRole, long>, ITransientDependency
         where TTenant : AbpTenant<TTenant, TUser>
         where TRole : AbpRole<TTenant, TUser>, new()
         where TUser : AbpUser<TTenant, TUser>
@@ -46,7 +46,7 @@ namespace Abp.Authorization.Roles
         protected AbpRoleStore<TTenant, TRole, TUser> AbpStore { get; private set; }
 
         private readonly IPermissionManager _permissionManager;
-        private readonly ITypedCache<int, RolePermissionCacheItem> _rolePermissionCache;
+        private readonly ITypedCache<long, RolePermissionCacheItem> _rolePermissionCache;
 
         /// <summary>
         /// Constructor.
@@ -90,7 +90,7 @@ namespace Abp.Authorization.Roles
         /// <param name="permissionName">Name of the permission</param>
         /// <returns>True, if the role has the permission</returns>
         [Obsolete("Use IsGrantedAsync instead.")]
-        public virtual async Task<bool> HasPermissionAsync(int roleId, string permissionName)
+        public virtual async Task<bool> HasPermissionAsync(long roleId, string permissionName)
         {
             return await IsGrantedAsync(roleId, _permissionManager.GetPermission(permissionName));
         }
@@ -114,7 +114,7 @@ namespace Abp.Authorization.Roles
         /// <param name="permission">The permission</param>
         /// <returns>True, if the role has the permission</returns>
         [Obsolete("Use IsGrantedAsync instead.")]
-        public Task<bool> HasPermissionAsync(int roleId, Permission permission)
+        public Task<bool> HasPermissionAsync(long roleId, Permission permission)
         {
             return IsGrantedAsync(roleId, permission);
         }
@@ -138,7 +138,7 @@ namespace Abp.Authorization.Roles
         /// <param name="roleId">The role's id to check it's permission</param>
         /// <param name="permissionName">Name of the permission</param>
         /// <returns>True, if the role has the permission</returns>
-        public virtual async Task<bool> IsGrantedAsync(int roleId, string permissionName)
+        public virtual async Task<bool> IsGrantedAsync(long roleId, string permissionName)
         {
             return await IsGrantedAsync(roleId, _permissionManager.GetPermission(permissionName));
         }
@@ -160,7 +160,7 @@ namespace Abp.Authorization.Roles
         /// <param name="roleId">role id</param>
         /// <param name="permission">The permission</param>
         /// <returns>True, if the role has the permission</returns>
-        public virtual async Task<bool> IsGrantedAsync(int roleId, Permission permission)
+        public virtual async Task<bool> IsGrantedAsync(long roleId, Permission permission)
         {
             //Get cached role permissions
             var cacheItem = await GetRolePermissionCacheItemAsync(roleId);
@@ -176,7 +176,7 @@ namespace Abp.Authorization.Roles
         /// </summary>
         /// <param name="roleId">Role id</param>
         /// <returns>List of granted permissions</returns>
-        public virtual async Task<IReadOnlyList<Permission>> GetGrantedPermissionsAsync(int roleId)
+        public virtual async Task<IReadOnlyList<Permission>> GetGrantedPermissionsAsync(long roleId)
         {
             return await GetGrantedPermissionsAsync(await GetRoleByIdAsync(roleId));
         }
@@ -363,7 +363,7 @@ namespace Abp.Authorization.Roles
         /// <param name="roleId">Role id</param>
         /// <returns>Role</returns>
         /// <exception cref="AbpException">Throws exception if no role with given id</exception>
-        public virtual async Task<TRole> GetRoleByIdAsync(int roleId)
+        public virtual async Task<TRole> GetRoleByIdAsync(long roleId)
         {
             var role = await FindByIdAsync(roleId);
             if (role == null)
@@ -422,7 +422,7 @@ namespace Abp.Authorization.Roles
             return IdentityResult.Success;
         }
 
-        public virtual async Task<IdentityResult> CheckDuplicateRoleNameAsync(int? expectedRoleId, string name, string displayName)
+        public virtual async Task<IdentityResult> CheckDuplicateRoleNameAsync(long? expectedRoleId, string name, string displayName)
         {
             var role = await FindByNameAsync(name);
             if (role != null && role.Id != expectedRoleId)
@@ -444,7 +444,7 @@ namespace Abp.Authorization.Roles
             return AbpStore.FindByDisplayNameAsync(displayName);
         }
 
-        private async Task<RolePermissionCacheItem> GetRolePermissionCacheItemAsync(int roleId)
+        private async Task<RolePermissionCacheItem> GetRolePermissionCacheItemAsync(long roleId)
         {
             return await _rolePermissionCache.GetAsync(roleId, async () =>
             {

--- a/src/Abp.Zero/Authorization/Roles/AbpRoleStore.cs
+++ b/src/Abp.Zero/Authorization/Roles/AbpRoleStore.cs
@@ -16,7 +16,7 @@ namespace Abp.Authorization.Roles
     /// Implements 'Role Store' of ASP.NET Identity Framework.
     /// </summary>
     public abstract class AbpRoleStore<TTenant, TRole, TUser> :
-        IQueryableRoleStore<TRole, int>,
+        IQueryableRoleStore<TRole, long>,
         IRolePermissionStore<TTenant, TRole, TUser>,
 
         IEventHandler<EntityChangedEventData<RolePermissionSetting>>,
@@ -28,7 +28,7 @@ namespace Abp.Authorization.Roles
         where TUser : AbpUser<TTenant, TUser>
         where TTenant : AbpTenant<TTenant, TUser>
     {
-        private readonly IRepository<TRole> _roleRepository;
+        private readonly IRepository<TRole, long> _roleRepository;
         private readonly IRepository<UserRole, long> _userRoleRepository;
         private readonly IRepository<RolePermissionSetting, long> _rolePermissionSettingRepository;
         private readonly ICacheManager _cacheManager;
@@ -37,7 +37,7 @@ namespace Abp.Authorization.Roles
         /// Constructor.
         /// </summary>
         protected AbpRoleStore(
-            IRepository<TRole> roleRepository, 
+            IRepository<TRole, long> roleRepository, 
             IRepository<UserRole, long> userRoleRepository,
             IRepository<RolePermissionSetting, long> rolePermissionSettingRepository,
             ICacheManager cacheManager)
@@ -69,7 +69,7 @@ namespace Abp.Authorization.Roles
             await _roleRepository.DeleteAsync(role);
         }
 
-        public virtual async Task<TRole> FindByIdAsync(int roleId)
+        public virtual async Task<TRole> FindByIdAsync(long roleId)
         {
             return await _roleRepository.FirstOrDefaultAsync(roleId);
         }
@@ -121,7 +121,7 @@ namespace Abp.Authorization.Roles
             return GetPermissionsAsync(role.Id);
         }
 
-        public async Task<IList<PermissionGrantInfo>> GetPermissionsAsync(int roleId)
+        public async Task<IList<PermissionGrantInfo>> GetPermissionsAsync(long roleId)
         {
             return (await _rolePermissionSettingRepository.GetAllListAsync(p => p.RoleId == roleId))
                 .Select(p => new PermissionGrantInfo(p.Name, p.IsGranted))
@@ -129,7 +129,7 @@ namespace Abp.Authorization.Roles
         }
 
         /// <inheritdoc/>
-        public virtual async Task<bool> HasPermissionAsync(int roleId, PermissionGrantInfo permissionGrant)
+        public virtual async Task<bool> HasPermissionAsync(long roleId, PermissionGrantInfo permissionGrant)
         {
             return await _rolePermissionSettingRepository.FirstOrDefaultAsync(
                 p => p.RoleId == roleId &&

--- a/src/Abp.Zero/Authorization/Roles/IRolePermissionStore.cs
+++ b/src/Abp.Zero/Authorization/Roles/IRolePermissionStore.cs
@@ -39,7 +39,7 @@ namespace Abp.Authorization.Roles
         /// </summary>
         /// <param name="roleId">Role id</param>
         /// <returns>List of permission setting informations</returns>
-        Task<IList<PermissionGrantInfo>> GetPermissionsAsync(int roleId);
+        Task<IList<PermissionGrantInfo>> GetPermissionsAsync(long roleId);
 
         /// <summary>
         /// Checks whether a role has a permission grant setting info.
@@ -47,7 +47,7 @@ namespace Abp.Authorization.Roles
         /// <param name="roleId">Role id</param>
         /// <param name="permissionGrant">Permission grant setting info</param>
         /// <returns></returns>
-        Task<bool> HasPermissionAsync(int roleId, PermissionGrantInfo permissionGrant);
+        Task<bool> HasPermissionAsync(long roleId, PermissionGrantInfo permissionGrant);
 
         /// <summary>
         /// Deleted all permission settings for a role.

--- a/src/Abp.Zero/Authorization/Roles/RolePermissionCacheItem.cs
+++ b/src/Abp.Zero/Authorization/Roles/RolePermissionCacheItem.cs
@@ -34,7 +34,7 @@ namespace Abp.Authorization.Roles
             ProhibitedPermissions = new HashSet<string>();
         }
 
-        public RolePermissionCacheItem(int roleId)
+        public RolePermissionCacheItem(long roleId)
             : this()
         {
             RoleId = roleId;

--- a/src/Abp.Zero/Authorization/Roles/RolePermissionSetting.cs
+++ b/src/Abp.Zero/Authorization/Roles/RolePermissionSetting.cs
@@ -8,6 +8,6 @@
         /// <summary>
         /// Role id.
         /// </summary>
-        public virtual int RoleId { get; set; }
+        public virtual long RoleId { get; set; }
     }
 }

--- a/src/Abp.Zero/Authorization/Users/AbpUser.cs
+++ b/src/Abp.Zero/Authorization/Users/AbpUser.cs
@@ -180,6 +180,10 @@ namespace Abp.Authorization.Users
         [ForeignKey("UserId")]
         public virtual ICollection<Setting> Settings { get; set; }
 
+        public virtual DateTime? LockoutEndDateUtc { get; set; }
+        public virtual int AccessFailedCount { get; set; }
+        public virtual bool LockoutEnabled { get; set; }
+
         public AbpUser()
         {
             IsActive = true;

--- a/src/Abp.Zero/Authorization/Users/AbpUserStore.cs
+++ b/src/Abp.Zero/Authorization/Users/AbpUserStore.cs
@@ -37,7 +37,7 @@ namespace Abp.Authorization.Users
         private readonly IRepository<TUser, long> _userRepository;
         private readonly IRepository<UserLogin, long> _userLoginRepository;
         private readonly IRepository<UserRole, long> _userRoleRepository;
-        private readonly IRepository<TRole> _roleRepository;
+        private readonly IRepository<TRole, long> _roleRepository;
         private readonly IRepository<UserPermissionSetting, long> _userPermissionSettingRepository;
         private readonly IUnitOfWorkManager _unitOfWorkManager;
         private readonly ICacheManager _cacheManager;
@@ -49,7 +49,7 @@ namespace Abp.Authorization.Users
             IRepository<TUser, long> userRepository,
             IRepository<UserLogin, long> userLoginRepository,
             IRepository<UserRole, long> userRoleRepository,
-            IRepository<TRole> roleRepository,
+            IRepository<TRole, long> roleRepository,
             IRepository<UserPermissionSetting, long> userPermissionSettingRepository,
             IUnitOfWorkManager unitOfWorkManager,
             ICacheManager cacheManager)

--- a/src/Abp.Zero/Authorization/Users/UserPermissionCacheItem.cs
+++ b/src/Abp.Zero/Authorization/Users/UserPermissionCacheItem.cs
@@ -21,7 +21,7 @@ namespace Abp.Authorization.Users
 
         public long UserId { get; set; }
 
-        public List<int> RoleIds { get; set; }
+        public List<long> RoleIds { get; set; }
 
         public HashSet<string> GrantedPermissions { get; set; }
 
@@ -34,7 +34,7 @@ namespace Abp.Authorization.Users
 
         public UserPermissionCacheItem()
         {
-            RoleIds = new List<int>();
+            RoleIds = new List<long>();
             GrantedPermissions = new HashSet<string>();
             ProhibitedPermissions = new HashSet<string>();
         }

--- a/src/Abp.Zero/Authorization/Users/UserRole.cs
+++ b/src/Abp.Zero/Authorization/Users/UserRole.cs
@@ -17,7 +17,7 @@ namespace Abp.Authorization.Users
         /// <summary>
         /// Role id.
         /// </summary>
-        public virtual int RoleId { get; set; }
+        public virtual long RoleId { get; set; }
 
         /// <summary>
         /// Creates a new <see cref="UserRole"/> object.
@@ -32,7 +32,7 @@ namespace Abp.Authorization.Users
         /// </summary>
         /// <param name="userId">User id</param>
         /// <param name="roleId">Role id</param>
-        public UserRole(long userId, int roleId)
+        public UserRole(long userId, long roleId)
         {
             UserId = userId;
             RoleId = roleId;

--- a/src/Abp.Zero/Runtime/Caching/AbpZeroCacheProviderExtensions.cs
+++ b/src/Abp.Zero/Runtime/Caching/AbpZeroCacheProviderExtensions.cs
@@ -10,9 +10,9 @@ namespace Abp.Runtime.Caching
             return cacheManager.GetCache(UserPermissionCacheItem.CacheStoreName).AsTyped<long, UserPermissionCacheItem>();
         }
 
-        public static ITypedCache<int, RolePermissionCacheItem> GetRolePermissionCache(this ICacheManager cacheManager)
+        public static ITypedCache<long, RolePermissionCacheItem> GetRolePermissionCache(this ICacheManager cacheManager)
         {
-            return cacheManager.GetCache(RolePermissionCacheItem.CacheStoreName).AsTyped<int, RolePermissionCacheItem>();
+            return cacheManager.GetCache(RolePermissionCacheItem.CacheStoreName).AsTyped<long, RolePermissionCacheItem>();
         }
     }
 }

--- a/src/Abp.Zero/Runtime/Session/AbpSession.cs
+++ b/src/Abp.Zero/Runtime/Session/AbpSession.cs
@@ -25,7 +25,10 @@ namespace Abp.Runtime.Session
                     return null;
                 }
 
-                return Convert.ToInt64(userId);
+                long id;
+                if (long.TryParse(userId, out id))
+                    return id;
+                return null;
             }
         }
 

--- a/src/Tests/Abp.Zero.SampleApp/Roles/RoleStore.cs
+++ b/src/Tests/Abp.Zero.SampleApp/Roles/RoleStore.cs
@@ -10,7 +10,7 @@ namespace Abp.Zero.SampleApp.Roles
     public class RoleStore : AbpRoleStore<Tenant, Role, User>
     {
         public RoleStore(
-            IRepository<Role> roleRepository,
+            IRepository<Role, long> roleRepository,
             IRepository<UserRole, long> userRoleRepository,
             IRepository<RolePermissionSetting, long> rolePermissionSettingRepository,
             ICacheManager cacheManager)

--- a/src/Tests/Abp.Zero.SampleApp/Users/UserStore.cs
+++ b/src/Tests/Abp.Zero.SampleApp/Users/UserStore.cs
@@ -13,7 +13,7 @@ namespace Abp.Zero.SampleApp.Users
             IRepository<User, long> userRepository,
             IRepository<UserLogin, long> userLoginRepository,
             IRepository<UserRole, long> userRoleRepository,
-            IRepository<Role> roleRepository,
+            IRepository<Role, long> roleRepository,
             IRepository<UserPermissionSetting, long> userPermissionSettingRepository,
             IUnitOfWorkManager unitOfWorkManager,
             ICacheManager cacheManager)


### PR DESCRIPTION
I am working on a graph-permission-system that allows item-level-permissions on database level.
For that I need "AbpRole" to has the same key type (long) as AbpUser, and not a different one (int)

Would it be thinkable to either change the type of role to "long" or make it configureable overall?
Because maybe someone wants all AbpUsers to have a Guid as an identifyer.
This may be required in synchronization scenarios.

I looked through the sources and could not find a show stopper for allowing arbitrary keys for AbpRole and ApbUser.

What do you think?