### PR TITLE
Fix inconsistent data type with mapping (using SchemaValidator to check)

### DIFF
--- a/src/Abp.Zero.NHibernate/Abp.Zero.NHibernate.csproj
+++ b/src/Abp.Zero.NHibernate/Abp.Zero.NHibernate.csproj
@@ -138,6 +138,7 @@
     <Compile Include="Zero\FluentMigrator\Migrations\_20151230_11_Create_Indexes_For_AbpUserOrganizationUnits.cs" />
     <Compile Include="Zero\FluentMigrator\Migrations\_20151230_12_Create_Indexes_For_AbpUserRoles.cs" />
     <Compile Include="Zero\FluentMigrator\Migrations\_20151230_13_Revise_Users.cs" />
+    <Compile Include="Zero\FluentMigrator\Migrations\_20160524_01_Fix_Inconsistent_Data_Type.cs" />
     <Compile Include="Zero\FluentMigrator\Migrations\_20160122_01_Create_AbpBackgroundJobs_Table.cs" />
     <Compile Include="Zero\FluentMigrator\VersionTable.cs" />
     <Compile Include="Zero\FluentMigrator\Migrations\_20140829_01_Add_Columns_To_AbpUsers_Table.cs" />

--- a/src/Abp.Zero.NHibernate/Zero/FluentMigrator/Migrations/_20160524_01_Fix_Inconsistent_Data_Type.cs
+++ b/src/Abp.Zero.NHibernate/Zero/FluentMigrator/Migrations/_20160524_01_Fix_Inconsistent_Data_Type.cs
@@ -1,0 +1,70 @@
+using Abp.FluentMigrator.Extensions;
+using FluentMigrator;
+
+namespace Abp.Zero.FluentMigrator.Migrations
+{
+    [Migration(2016052401)]
+    public class _20160524_01_Fix_Inconsistent_Data_Type : Migration
+    {
+        public override void Up()
+        {
+            this.Delete.PrimaryKey("PK_AbpBackgroundJobs")
+               .FromTable("AbpBackgroundJobs");
+            this.Alter.Column("Id").OnTable("AbpBackgroundJobs")
+                .AsInt64().NotNullable();
+            this.Create.PrimaryKey("PK_AbpBackgroundJobs")
+                .OnTable("AbpBackgroundJobs")
+                .Column("Id");
+
+            this.Delete.Index("IX_RoleId_Name")
+                .OnTable("AbpPermissions");
+            this.Delete.Index("IX_UserId_Name")
+                .OnTable("AbpPermissions");
+            this.Alter.Column("Name")
+                .OnTable("AbpPermissions")
+                .AsString(128)
+                .NotNullable();
+
+            this.Create.Index("IX_RoleId_Name")
+                .OnTable("AbpPermissions")
+                .OnColumn("RoleId").Ascending()
+                .OnColumn("Name").Ascending()
+                .WithOptions().NonClustered();
+            this.Create.Index("IX_UserId_Name")
+                .OnTable("AbpPermissions")
+                .OnColumn("UserId").Ascending()
+                .OnColumn("Name").Ascending()
+                .WithOptions().NonClustered();
+        }
+
+        public override void Down()
+        {
+            this.Delete.Index("IX_RoleId_Name")
+                .OnTable("AbpPermissions");
+            this.Delete.Index("IX_UserId_Name")
+                .OnTable("AbpPermissions");
+            this.Alter.Column("Name")
+                .OnTable("AbpPermissions")
+                .AsAnsiString(128)
+                .NotNullable();
+            this.Create.Index("IX_RoleId_Name")
+                .OnTable("AbpPermissions")
+                .OnColumn("RoleId").Ascending()
+                .OnColumn("Name").Ascending()
+                .WithOptions().NonClustered();
+            this.Create.Index("IX_UserId_Name")
+                .OnTable("AbpPermissions")
+                .OnColumn("UserId").Ascending()
+                .OnColumn("Name").Ascending()
+                .WithOptions().NonClustered();
+
+            this.Delete.PrimaryKey("PK_AbpBackgroundJobs")
+                .FromTable("AbpBackgroundJobs");
+            this.Alter.Column("Id").OnTable("AbpBackgroundJobs")
+                .AsInt32().NotNullable().PrimaryKey("PK_AbpBackgroundJobs");
+            this.Create.PrimaryKey("PK_AbpBackgroundJobs")
+                .OnTable("AbpBackgroundJobs")
+                .Column("Id");
+        }
+    }
+}


### PR DESCRIPTION
The AbpBackgrounJobs.Id should be bigint (long) and AbpPermissions.Name should be nvarchar. Otherwise, the SchemaValidator will complain.